### PR TITLE
Pinned down dependency versions.

### DIFF
--- a/lib/polyclay.js
+++ b/lib/polyclay.js
@@ -31,6 +31,7 @@ PolyClay.Model.buildClass = function(options, methods)
 	sub.prototype.__init       = options.initialize;
 	sub.prototype.singular     = options.singular;
 	sub.prototype.plural       = options.plural;
+	sub.prototype.__index      = options.index;
 
 	var props = Object.keys(options.properties || {});
 	_.each(props, function(k)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name":           "polyclay",
-	"version":        "1.6.4",
+	"version":        "1.6.5",
 	"description":    "a schema-enforcing model class for node with optional key-value store persistence",
 	"author":         "C J Silverio <ceejceej@gmail.com>",
 	"contributors":
@@ -21,11 +21,11 @@
 		"test":       "node_modules/.bin/mocha -R spec -t 5000 test/test-*.js && node_modules/.bin/mocha -t 5000 --require blanket -R travis-cov test/test-*.js",
 		"test-cov":   "node_modules/.bin/mocha --require blanket -R travis-cov test/test-*.js",
 		"coverage":   "node_modules/.bin/mocha --require blanket -R html-cov test/test-*.js > test/coverage.html",
-		"travis-cov": { "threshold": 80 },
-		"blanket":
-		{
-			"pattern": "//^((?!\/node_modules|test|examples\/).)*$/ig"
-		}
+		"travis-cov": { "threshold": 80 }
+	},
+	"config":
+	{
+		"blanket": { "pattern": "//^((?!\/node_modules|test|examples\/).)*$/ig" }
 	},
 	"repository":
 	{
@@ -34,9 +34,9 @@
 	},
 	"dependencies":
 	{
-		"lodash":    "*",
+		"lodash":    "~2.4.1",
 		"lucidjs":   "~2.7.0",
-		"p-promise": "*"
+		"p-promise": "~0.2.5"
 	},
 	"devDependencies":
 	{

--- a/test/test-01-polyclay.js
+++ b/test/test-01-polyclay.js
@@ -34,6 +34,7 @@ var modelDefinition =
 	required: [ 'name', 'is_valid', 'required_prop'],
 	singular: 'model',
 	plural: 'models',
+	index: [ 'key', 'name' ],
 	enumerables:
 	{
 		enum1: ['zero', 'one', 'two'],
@@ -81,6 +82,11 @@ describe('polyclay', function()
 		Model.prototype.should.have.property('supplied');
 		(typeof Model.prototype.supplied).should.equal('function');
 		instance.supplied().should.equal(true);
+	});
+
+	it('sets the `__index` property on the prototype if index is in the options', function()
+	{
+		Model.prototype.should.have.property('__index');
 	});
 
 	it('defines getters and setters for typed properties', function()


### PR DESCRIPTION
Added a minor feature to pass through any `index` field in the model options
to the model's prototype, for use by adapters as they see fit.
